### PR TITLE
changed deserialization to use string cast on response body

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -350,7 +350,7 @@ final class Client implements Contracts\Client
 
 
         $responseObject = $this->serializer->deserialize(
-            $response->getBody()->getContents(),
+            (string) $response->getBody(),
             $responsePayload,
             'json',
         );


### PR DESCRIPTION
changed the deserialization process in the `Client` class to use `(string) $response->getBody()` instead of `$response->getBody()->getContents()`.

This change ensures that the response body is correctly read and deserialized, preventing potential issues with stream handling.