### PR TITLE
feat: add support for Laravel 12 and update brick/money

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   "require": {
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.0",
-    "illuminate/support": "^8|^9.0|^10.0|^11.0",
+    "illuminate/support": "^8|^9.0|^10.0|^11.0|^12.0",
     "jms/serializer": "^3.12",
-    "brick/money": "^0.8.0",
+    "brick/money": "^0.11.0",
     "ratchet/pawl": "^0.3.5",
     "webmozart/assert": "^1.10"
   },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "illuminate/support": "^8|^9.0|^10.0|^11.0|^12.0",
     "jms/serializer": "^3.12",
     "brick/money": "^0.11.0",
-    "ratchet/pawl": "^0.3.5",
+    "ratchet/pawl": "^0.3.5 || ^0.4",
     "webmozart/assert": "^1.10"
   },
   "require-dev": {


### PR DESCRIPTION
Extends supported Illuminate versions to include Laravel 12, allowing projects to upgrade without dependency issues. Updates brick/money to ^0.11.0, ensuring compatibility with latest packages.

- No breaking changes expected
- Enables smoother upgrades for Laravel-based projects

Relates to #laravel-12-support